### PR TITLE
[ADYENPAY-1] App Review

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+
+- Move error logging to connector from clients
+
+### Added
+
+- Admin navigation restrictions
+- Error logging
+
 ## [0.1.2] - 2022-02-11
 
 ## [0.1.1] - 2022-01-31

--- a/admin/navigation.json
+++ b/admin/navigation.json
@@ -1,7 +1,26 @@
- 
-{
-    "section": "other",
-    "path": "/admin/adyen",
-    "icon": "extensions-ic",
-    "titleId": "admin/adyen.admin-menu-button"
+[
+  {
+    "section": "transactions",
+    "subSection": "payments",
+    "LMProductId": "6",
+    "subSectionItems": [
+      {
+        "labelId": "admin/adyen.admin-menu-button",
+        "path": "/admin/adyen"
+      }
+    ],
+    "icon": "extensions-ic"
+  },
+  {
+    "adminVersion": 4,
+    "section": "storeSettings",
+    "subSection": "payment",
+    "LMProductId": "6",
+    "subSectionItems": [
+      {
+        "labelId": "admin/adyen.admin-menu-button",
+        "path": "/admin/adyen"
+      }
+    ]
   }
+]

--- a/docs/README.md
+++ b/docs/README.md
@@ -29,7 +29,7 @@ Before you can configure the VTEX Adyen connector, you will need to do the follo
 3. In Merchant Settings, update the Capture Delay option to `manual`. This allows VTEX to handle payment capture timing.
 4. Create a Standard Notification Webhook
    - Use `https://{accountName}.myvtex.com/_v/api/connector-adyen/v0/hook` for the URL
-      - Example: `https://mysampleshop.myvtex.com/_v/api/connector-adyen/v0/hook`
+     - Example: `https://mysampleshop.myvtex.com/_v/api/connector-adyen/v0/hook`
    - Make sure `Service Version` is `1`
    - Make sure the webhook is marked as `active`
    - Make sure `Method` is set to `JSON`
@@ -49,10 +49,11 @@ Before you can configure the VTEX Adyen connector, you will need to do the follo
 10. In your admin sidebar, search for `Adyen`. This will bring you to the `Adyen` admin panel to configure the app settings.
 11. Complete the settings with the values from your Adyen setup, following the guide below.
 
-
 ### App Configurations
 
-1. `Adyen Merchant Account` is the merchant account name. 
+> ⚠️ _Only users with access to the **Payments** section in the VTEX admin (or assigned the **PCI Gateway** role in License Manager) will be able to configure the app._
+
+1. `Adyen Merchant Account` is the merchant account name.
    - Note: This is not the company name.
 2. `Adyen API Key` is the API key that is generated in Step 1 of `Adyen Setup`
 3. `Adyen Production API URI` is the Checkout API's URI.
@@ -60,8 +61,9 @@ Before you can configure the VTEX Adyen connector, you will need to do the follo
    - Example: `http://checkout-test.adyen.com`
    - Note: Please use http instead of https
 4. `Adyen Webhook Username` and `Adyen Webhook Password` is the Username/Password created in Step 4 of `Adyen Setup`
-5. `VTEX App Key/App Token` should be a VTEX application key that has the `Super Admin` role in your account and its associated token. Reference [this documentation](https://help.vtex.com/en/tutorial/application-keys--2iffYzlvvz4BDMr6WGUtet) for app key generation and configuration. 
-  - If you are running Adyen in a marketplace, make sure to grant this application key the same `Super Admin` role on all seller accounts as well. In other words, create the application key on the marketplace account, then go to the `Application Keys` admin panel on each seller account and click `+ Add` to grant the key permissions for that account.
+5. `VTEX App Key/App Token` should be a VTEX application key that has the `Super Admin` role in your account and its associated token. Reference [this documentation](https://help.vtex.com/en/tutorial/application-keys--2iffYzlvvz4BDMr6WGUtet) for app key generation and configuration.
+
+- If you are running Adyen in a marketplace, make sure to grant this application key the same `Super Admin` role on all seller accounts as well. In other words, create the application key on the marketplace account, then go to the `Application Keys` admin panel on each seller account and click `+ Add` to grant the key permissions for that account.
 
 <!-- DOCS-IGNORE:start -->
 

--- a/node/clients/adyen.ts
+++ b/node/clients/adyen.ts
@@ -17,29 +17,19 @@ export default class Adyen extends ExternalClient {
     data,
     settings,
   }: any): Promise<AdyenCaptureResponse | null> {
-    try {
-      return await this.http.post(
-        `${this.getEndpoint(settings)}/v67/payments/${pspReference}/captures
+    return this.http.post(
+      `${this.getEndpoint(settings)}/v67/payments/${pspReference}/captures
         `,
-        data,
-        {
-          headers: {
-            'X-API-Key': settings.apiKey,
-            'X-Vtex-Use-Https': 'true',
-            'Content-Type': 'application/json',
-          },
-          metric: 'connectorAdyen-capture',
-        }
-      )
-    } catch (error) {
-      this.context.logger.error({
-        error,
-        message: 'connecotAdyen-adyenSettleRequestError',
-        data: { pspReference, request: data },
-      })
-
-      return null
-    }
+      data,
+      {
+        headers: {
+          'X-API-Key': settings.apiKey,
+          'X-Vtex-Use-Https': 'true',
+          'Content-Type': 'application/json',
+        },
+        metric: 'connectorAdyen-capture',
+      }
+    )
   }
 
   public async cancel(
@@ -47,28 +37,18 @@ export default class Adyen extends ExternalClient {
     data: AdyenCancelRequest,
     appSettings: AppSettings
   ): Promise<AdyenCancelResponse | null> {
-    try {
-      return await this.http.post(
-        `${this.getEndpoint(appSettings)}/v67/payments/${pspReference}/cancels`,
-        data,
-        {
-          headers: {
-            'X-API-Key': appSettings.apiKey,
-            'X-Vtex-Use-Https': 'true',
-            'Content-Type': 'application/json',
-          },
-          metric: 'connectorAdyen-cancel',
-        }
-      )
-    } catch (error) {
-      this.context.logger.error({
-        error,
-        message: 'connectorAdyen-adyenCancelRequestError',
-        data: { pspReference, request: data },
-      })
-
-      return null
-    }
+    return this.http.post(
+      `${this.getEndpoint(appSettings)}/v67/payments/${pspReference}/cancels`,
+      data,
+      {
+        headers: {
+          'X-API-Key': appSettings.apiKey,
+          'X-Vtex-Use-Https': 'true',
+          'Content-Type': 'application/json',
+        },
+        metric: 'connectorAdyen-cancel',
+      }
+    )
   }
 
   public async refund({
@@ -76,28 +56,18 @@ export default class Adyen extends ExternalClient {
     data,
     settings,
   }: AdyenRefundRequest): Promise<AdyenRefundResponse | null> {
-    try {
-      return await this.http.post(
-        `${this.getEndpoint(settings)}/v67/payments/${pspReference}/refunds
+    return this.http.post(
+      `${this.getEndpoint(settings)}/v67/payments/${pspReference}/refunds
     `,
-        data,
-        {
-          headers: {
-            'X-API-Key': settings.apiKey,
-            'X-Vtex-Use-Https': 'true',
-            'Content-Type': 'application/json',
-          },
-          metric: 'connectorAdyen-refund',
-        }
-      )
-    } catch (error) {
-      this.context.logger.error({
-        error,
-        message: 'connectorAdyen-adyenRefundRequestError',
-        data: { pspReference, request: data },
-      })
-
-      return null
-    }
+      data,
+      {
+        headers: {
+          'X-API-Key': settings.apiKey,
+          'X-Vtex-Use-Https': 'true',
+          'Content-Type': 'application/json',
+        },
+        metric: 'connectorAdyen-refund',
+      }
+    )
   }
 }

--- a/node/clients/adyenPlatforms.ts
+++ b/node/clients/adyenPlatforms.ts
@@ -11,24 +11,11 @@ export default class Platforms extends ExternalClient {
   }
 
   public async getAccounts(ctx: Context, sellers: string[]): Promise<any> {
-    try {
-      return await this.http.get(
-        `/v0/account?seller=${sellers.join('&seller=')}`,
-        {
-          headers: {
-            VtexIdclientAutCookie: ctx.vtex.authToken,
-          },
-          metric: 'connectorAdyen-getAccounts',
-        }
-      )
-    } catch (error) {
-      this.context.logger.error({
-        error,
-        message: 'connectorAdyen-getAccountsRequest',
-        data: { sellers },
-      })
-
-      return null
-    }
+    return this.http.get(`/v0/account?seller=${sellers.join('&seller=')}`, {
+      headers: {
+        VtexIdclientAutCookie: ctx.vtex.authToken,
+      },
+      metric: 'connectorAdyen-getAccounts',
+    })
   }
 }

--- a/node/clients/adyenSecure.ts
+++ b/node/clients/adyenSecure.ts
@@ -17,29 +17,17 @@ export default class AdyenSecure extends SecureExternalClient {
     settings,
     secureProxyUrl,
   }: AdyenPaymentRequest): Promise<AdyenPaymentResponse | null> {
-    try {
-      const response = await this.http.postRaw<AdyenPaymentResponse>(
-        `/checkout/v67/payments`,
-        data,
-        {
-          headers: {
-            'X-API-Key': settings.apiKey,
-            'X-Vtex-Use-Https': 'true',
-          },
-          secureProxy: secureProxyUrl,
-          metric: 'connectorAdyen-payment',
-        } as RequestConfig
-      )
-
-      return response.data
-    } catch (error) {
-      this.context.logger.error({
-        error,
-        message: 'connectorAdyen-adyenPaymentRequest',
-        data,
-      })
-
-      return null
-    }
+    return this.http.post<AdyenPaymentResponse>(
+      `/checkout/v67/payments`,
+      data,
+      {
+        headers: {
+          'X-API-Key': settings.apiKey,
+          'X-Vtex-Use-Https': 'true',
+        },
+        secureProxy: secureProxyUrl,
+        metric: 'connectorAdyen-payment',
+      } as RequestConfig
+    )
   }
 }

--- a/node/services/adyen.ts
+++ b/node/services/adyen.ts
@@ -26,11 +26,26 @@ const handleSplit = async (
 
   if (!sellers.length) return undefined
 
+  const {
+    clients: { platforms },
+    vtex: { logger },
+  } = ctx
+
   const sellerIds = sellers.map((seller) => seller.id)
-  const accounts = await ctx.clients.platforms.getAccounts(ctx, sellerIds)
+  let accounts: any = null
+
+  try {
+    accounts = await platforms.getAccounts(ctx, sellerIds)
+  } catch (error) {
+    logger.error({
+      error,
+      message: 'connectorAdyen-getAccountsRequestError',
+      data: { sellerIds },
+    })
+  }
 
   if (!accounts) {
-    ctx.vtex.logger.warn({
+    logger.warn({
       message: 'connectorAdyen-NoSplitAccountsReturned',
       data: { recipients },
     })

--- a/node/typings/adyen.d.ts
+++ b/node/typings/adyen.d.ts
@@ -69,25 +69,6 @@ interface CheckoutAwaitAction {
   url: string
 }
 
-// interface AdyenPaymentMethodResponse {
-//   paymentMethods: any[]
-//   storedPaymentMethods: any[]
-// }
-
-// interface AdyenPaymentMethod {
-//   merchantAccount: string
-//   allowedPaymentMethods?: string[]
-//   amount?: Amount
-//   blockedPaymentMethods?: string[]
-//   channel?: string
-//   countryCode: string
-//   order: Order
-//   shopperLocale: string
-//   shopperReference: string
-//   splitCardFundingSources: string
-//   store: string
-// }
-
 interface AdyenPayment {
   merchantAccount: string
   amount: Amount
@@ -100,11 +81,6 @@ interface Amount {
   currency: string
   value: number
 }
-
-// interface Order {
-//   orderData: string
-//   pspReference: number
-// }
 
 interface PaymentType {
   type: string


### PR DESCRIPTION
**What problem is this solving?**

App review changes per [checklist in Notion](https://www.notion.so/vtexhandbook/2022-Q3-App-Review-Checklist-a68487945f864ce0a2b216a43d31efa3):

- Admin navigation permissions: Restrict access to Adyen connector settings page to users with LMProductId: 6 ([PCI Gateway](https://vtex.myvtex.com/admin/resources-manager/6/)) access
- Add error logging, moving logic from client to resolvers

**How should this be manually tested?**

Test in workspace [annaadyenplat](https://annaadyenplat--sandboxusdev.myvtex.com/) by placing test orders.

**Screenshots or example usage:**

Here are two orders/transactions using the version linked in the workspace:

- [1258242637623-01](https://annaadyenplat--sandboxusdev.myvtex.com/admin/checkout/#/orders/seq612963?orderBy=creationDate,desc&f_creationDate=creationDate:%5B2022-08-31T04:00:00.000Z%20TO%202022-09-01T03:59:59.999Z%5D) ([transaction](https://annaadyenplat--sandboxusdev.myvtex.com/admin/pci-gateway/#/transactions/5B0101129CC1487C9ADABCA6A10B2774)) - authorized, settled, refund
- [1258242736553-01](https://annaadyenplat--sandboxusdev.myvtex.com/admin/checkout/#/orders/seq612965?orderBy=creationDate,desc&f_creationDate=creationDate:%5B2022-08-31T04:00:00.000Z%20TO%202022-09-01T03:59:59.999Z%5D) ([transaction](https://annaadyenplat--sandboxusdev.myvtex.com/admin/iframe/pci-gateway#/transactions/0E20DD56D8AF43ECA2A1E5D3BA304ABF)) - authorized, canceled